### PR TITLE
Use the same libp2p host for storage and retrieval client.

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -276,7 +276,14 @@ var clientDealCmd = &cli.Command{
 			ref.TransferType = storagemarket.TTManual
 		}
 
-		isVerified := false
+		// Check if the address is a verified client
+		dcap, err := nodeapi.StateVerifiedClientStatus(ctx, a, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+
+		isVerified := dcap != nil
+
 		// If the user has explicitly set the --verified-deal flag
 		if cctx.IsSet("verified-deal") {
 			// If --verified-deal is true, but the address is not a verified

--- a/main.go
+++ b/main.go
@@ -32,13 +32,18 @@ func main() {
 	log.Infof("Initialized node client")
 	nodeapi.NodeClient = nodeClient
 
-	storageClient, storageClientInfo, err := storageadapter.InitStorageClient()
+	host, err := nodeapi.NewLibP2PHost()
+	if err != nil {
+		log.Fatalf("Error while initializing LibP2P host: %s", err)
+	}
+
+	storageClient, storageClientInfo, err := storageadapter.InitStorageClient(host)
 	if err != nil {
 		log.Fatalf("Error while initializing storage client: %s", err)
 	}
 	log.Infof("Initialized storage market")
 
-	retrievalClient, err := retrievaladapter.InitRetrievalClient()
+	retrievalClient, err := retrievaladapter.InitRetrievalClient(host)
 	if err != nil {
 		log.Fatalf("Error while initializing retrieval client: %s", err)
 	}

--- a/nodeapi/client.go
+++ b/nodeapi/client.go
@@ -5,6 +5,7 @@ package nodeapi
 
 import (
 	"context"
+	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"net/http"
 
@@ -61,6 +62,7 @@ type StateAPI struct {
 	StateGetActor                     func(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error)
 	StateGetReceipt                   func(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)
 	StateDealProviderCollateralBounds func(context.Context, abi.PaddedPieceSize, bool, types.TipSetKey) (api.DealCollateralBounds, error)
+	StateVerifiedClientStatus         func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*verifreg.DataCap, error)
 }
 
 type StateManagerAPI struct {

--- a/nodeapi/utils.go
+++ b/nodeapi/utils.go
@@ -6,6 +6,9 @@ package nodeapi
 import (
 	"context"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 
@@ -45,4 +48,21 @@ func NewStorageProviderInfo(address address.Address, miner address.Address, sect
 		PeerID:     peer,
 		Addrs:      multiaddrs,
 	}
+}
+
+func NewLibP2PHost() (host.Host, error) {
+	ctx := context.Background()
+	priv, _, err := crypto.GenerateKeyPair(crypto.RSA, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := []libp2p.Option{
+		libp2p.Identity(priv),
+		libp2p.DefaultTransports,
+		libp2p.DefaultMuxers,
+		libp2p.DefaultSecurity,
+		libp2p.NATPortMap(),
+	}
+	return libp2p.New(ctx, opts...)
 }


### PR DESCRIPTION
## Description
Use same libp2p host for storage and retrieval client

## Changes
-  Use the same libp2p host for storage and retrieval client.
- Add `StateVerifiedClientStatus` api.